### PR TITLE
Add REST API documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,9 @@ authentication for integration tests and is activated when running with the
 Any documentation (especially javadoc and comments in code) shall be written in english.
 Also documentation in AGENTS.md and any available README.md files shall be written in english.
 
+## REST API Documentation
+The file `docs/rest_api.md` explains the available REST endpoints and how the Vue frontend consumes them. Keep this document up to date whenever the API or its usage changes.
+
 ## AGENTS.md Maintenance
 
 The instructions in this file must accurately reflect the repository. Whenever

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1,0 +1,58 @@
+# Goldmanager REST API Overview
+
+This document provides an overview of the backend REST API and how it is consumed by the Vue UI.
+
+## Overview
+
+The backend exposes a set of endpoints under the `/api` prefix. They allow management of materials, items and prices of precious metals. Authentication is handled with JWT tokens. During development the `dev` Spring profile enables CORS to allow local UI servers.
+
+## Authentication
+
+The `AuthController` offers `/api/auth/login` to obtain a JWT token. The token must be included as `Authorization: Bearer <token>` in subsequent requests. `/api/auth/refresh` provides token refresh and `/api/auth/logoutuser` clears the server side session.
+
+## Main Endpoints
+
+| Resource | Base URL | Sample operations |
+|----------|---------|------------------|
+| Items | `/api/items` | `POST`, `PUT /{id}`, `GET /{id}`, `DELETE /{id}`, list all via `GET` |
+| Item Types | `/api/itemTypes` | CRUD operations similar to items |
+| Item Storages | `/api/itemStorages` | CRUD operations |
+| Materials | `/api/materials` | CRUD operations |
+| Material History | `/api/materialHistory` | `GET /{materialId}` to list history |
+| Units | `/api/units` | `GET`, `GET /{name}`, `POST`, `PUT /{name}`, `DELETE /{name}` |
+| Prices | `/api/prices` | `GET` list, `GET /item/{id}`, `GET /material/{id}`, `GET /itemStorage/{id}`, grouping endpoints |
+| Price History | `/api/priceHistory` | `GET /{materialId}` with optional `startDate` and `endDate` |
+| User Service | `/api/userService` | endpoints for managing users |
+
+The controllers reside under `backend/src/main/java/com/my/goldmanager/controller/`.
+
+## Integration with the UI
+
+The Vue frontend uses Axios (`src/axios.js`) configured with the base URL `/api/`. The Axios instance automatically attaches the stored JWT token and refreshes it when needed. Components invoke the API through this instance to retrieve or modify data. Routes defined in `src/router/index.js` guard access and redirect to `/login` when no token is present.
+
+To start a local development environment:
+
+```bash
+# Start database
+docker compose -f backend/dev-env/compose.yaml up -d
+
+# Run backend
+cd backend
+./gradlew bootRun
+
+# Run frontend
+cd ../frontend
+npm install
+npm run serve
+```
+
+## Example Workflow
+
+1. Authenticate via POST `/api/auth/login`.
+2. Use the received token to create a material with POST `/api/materials`.
+3. Add an item referencing that material with POST `/api/items`.
+4. Fetch current prices using GET `/api/prices`.
+5. View the data in the UI under `/items` or `/metals` routes.
+
+Keep this document updated whenever endpoints or authentication behaviour change so that it remains a reliable reference.
+


### PR DESCRIPTION
## Summary
- add documentation for REST API and UI usage under `docs/rest_api.md`
- reference the new guide from AGENTS.md with a note to keep it updated

## Testing
- `./gradlew test`
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d0fb2c788326b5c5b76966743ff0