### PR TITLE
Add detailed job status with messages

### DIFF
--- a/backend/src/main/java/com/my/goldmanager/controller/DataExportController.java
+++ b/backend/src/main/java/com/my/goldmanager/controller/DataExportController.java
@@ -31,6 +31,7 @@ import com.my.goldmanager.service.DataExportStatusService;
 import com.my.goldmanager.service.entity.JobStatus;
 import com.my.goldmanager.service.exception.BadRequestException;
 import com.my.goldmanager.service.exception.ExportInProgressException;
+import com.my.goldmanager.rest.response.JobStatusResponse;
 
 @RestController
 @RequestMapping("/api/dataexport")
@@ -51,8 +52,10 @@ public class DataExportController {
         }
 
         @GetMapping("/status")
-        public ResponseEntity<JobStatus> getStatus() {
-                return ResponseEntity.ok(dataExportStatusService.getStatus());
+        public ResponseEntity<JobStatusResponse> getStatus() {
+                return ResponseEntity
+                                .ok(new JobStatusResponse(dataExportStatusService.getStatus(),
+                                                dataExportStatusService.getMessage()));
         }
 
         @GetMapping("/download")

--- a/backend/src/main/java/com/my/goldmanager/controller/DataImportController.java
+++ b/backend/src/main/java/com/my/goldmanager/controller/DataImportController.java
@@ -18,6 +18,7 @@ import com.my.goldmanager.service.ImportStatusService;
 import com.my.goldmanager.service.entity.JobStatus;
 import com.my.goldmanager.service.exception.ImportInProgressException;
 import com.my.goldmanager.service.exception.BadRequestException;
+import com.my.goldmanager.rest.response.JobStatusResponse;
 
 @RestController
 @RequestMapping("/api/dataimport")
@@ -40,8 +41,10 @@ public class DataImportController {
         }
 
         @GetMapping("/status")
-        public ResponseEntity<JobStatus> getStatus() {
-                return ResponseEntity.ok(importStatusService.getStatus());
+        public ResponseEntity<JobStatusResponse> getStatus() {
+                return ResponseEntity
+                                .ok(new JobStatusResponse(importStatusService.getStatus(),
+                                                importStatusService.getMessage()));
         }
 
         @ExceptionHandler(ImportInProgressException.class)

--- a/backend/src/main/java/com/my/goldmanager/rest/response/JobStatusResponse.java
+++ b/backend/src/main/java/com/my/goldmanager/rest/response/JobStatusResponse.java
@@ -1,0 +1,23 @@
+package com.my.goldmanager.rest.response;
+
+import com.my.goldmanager.service.entity.JobStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Response containing the current job status and an optional message.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+public class JobStatusResponse {
+    @Getter
+    @Setter
+    private JobStatus status;
+
+    @Getter
+    @Setter
+    private String message;
+}

--- a/backend/src/main/java/com/my/goldmanager/service/ImportStatusService.java
+++ b/backend/src/main/java/com/my/goldmanager/service/ImportStatusService.java
@@ -9,11 +9,13 @@ import org.springframework.stereotype.Service;
 
 import com.my.goldmanager.service.entity.JobStatus;
 import com.my.goldmanager.service.exception.ImportInProgressException;
+import com.my.goldmanager.service.exception.ValidationException;
 
 @Service
 public class ImportStatusService {
 
     private final AtomicReference<JobStatus> status = new AtomicReference<>(JobStatus.IDLE);
+    private final AtomicReference<String> message = new AtomicReference<>("");
 
     @Autowired
     private DataImportService dataImportService;
@@ -26,6 +28,7 @@ public class ImportStatusService {
             throw new ImportInProgressException("Import already running");
         }
         status.set(JobStatus.RUNNING);
+        message.set("");
         applicationContext.getBean(ImportStatusService.class).executeImport(data, password);
     }
 
@@ -34,12 +37,21 @@ public class ImportStatusService {
         try {
             dataImportService.importData(data, password);
             status.set(JobStatus.SUCCESS);
+            message.set("");
+        } catch (ValidationException | IllegalArgumentException e) {
+            status.set(JobStatus.PASSWORD_ERROR);
+            message.set(e.getMessage());
         } catch (Exception e) {
             status.set(JobStatus.FAILED);
+            message.set(e.getMessage());
         }
     }
 
     public JobStatus getStatus() {
         return status.get();
+    }
+
+    public String getMessage() {
+        return message.get();
     }
 }

--- a/backend/src/main/java/com/my/goldmanager/service/entity/JobStatus.java
+++ b/backend/src/main/java/com/my/goldmanager/service/entity/JobStatus.java
@@ -4,5 +4,6 @@ public enum JobStatus {
     IDLE,
     RUNNING,
     SUCCESS,
-    FAILED
+    FAILED,
+    PASSWORD_ERROR
 }

--- a/backend/src/test/java/com/my/goldmanager/service/DataExportStatusServiceSpringBootTest.java
+++ b/backend/src/test/java/com/my/goldmanager/service/DataExportStatusServiceSpringBootTest.java
@@ -30,6 +30,7 @@ class DataExportStatusServiceSpringBootTest {
         Mockito.verify(dataExportService, Mockito.timeout(1000)).exportData(Mockito.any());
         Thread.sleep(50);
         assertEquals(JobStatus.SUCCESS, dataExportStatusService.getStatus());
+        assertEquals("", dataExportStatusService.getMessage());
     }
 
     @Test
@@ -43,6 +44,7 @@ class DataExportStatusServiceSpringBootTest {
         Mockito.verify(dataExportService, Mockito.timeout(1000)).exportData(Mockito.any());
         Thread.sleep(350);
         assertEquals(JobStatus.SUCCESS, dataExportStatusService.getStatus());
+        assertEquals("", dataExportStatusService.getMessage());
     }
 
     @Test
@@ -52,5 +54,17 @@ class DataExportStatusServiceSpringBootTest {
         Mockito.verify(dataExportService, Mockito.timeout(1000)).exportData(Mockito.any());
         Thread.sleep(50);
         assertEquals(JobStatus.FAILED, dataExportStatusService.getStatus());
+        assertEquals("fail", dataExportStatusService.getMessage());
+    }
+
+    @Test
+    void testPasswordErrorStatus() throws Exception {
+        Mockito.doThrow(new IllegalArgumentException("Password invalid"))
+                .when(dataExportService).exportData(Mockito.any());
+        dataExportStatusService.startExport("bad");
+        Mockito.verify(dataExportService, Mockito.timeout(1000)).exportData(Mockito.any());
+        Thread.sleep(50);
+        assertEquals(JobStatus.PASSWORD_ERROR, dataExportStatusService.getStatus());
+        assertEquals("Password invalid", dataExportStatusService.getMessage());
     }
 }

--- a/backend/src/test/java/com/my/goldmanager/service/ImportStatusServiceSpringBootTest.java
+++ b/backend/src/test/java/com/my/goldmanager/service/ImportStatusServiceSpringBootTest.java
@@ -29,6 +29,7 @@ class ImportStatusServiceSpringBootTest {
         Mockito.verify(dataImportService, Mockito.timeout(1000)).importData(Mockito.any(), Mockito.any());
         Thread.sleep(50);
         assertEquals(JobStatus.SUCCESS, importStatusService.getStatus());
+        assertEquals("", importStatusService.getMessage());
     }
 
     @Test
@@ -43,6 +44,7 @@ class ImportStatusServiceSpringBootTest {
         Mockito.verify(dataImportService, Mockito.timeout(1000)).importData(Mockito.any(), Mockito.any());
         Thread.sleep(350);
         assertEquals(JobStatus.SUCCESS, importStatusService.getStatus());
+        assertEquals("", importStatusService.getMessage());
     }
 
     @Test
@@ -52,6 +54,7 @@ class ImportStatusServiceSpringBootTest {
         Mockito.verify(dataImportService, Mockito.timeout(1000)).importData(Mockito.any(), Mockito.any());
         Thread.sleep(50);
         assertEquals(JobStatus.FAILED, importStatusService.getStatus());
+        assertEquals("fail", importStatusService.getMessage());
     }
 
     @Test
@@ -62,6 +65,8 @@ class ImportStatusServiceSpringBootTest {
         importStatusService.startImport("data".getBytes(), "bad");
         Mockito.verify(dataImportService, Mockito.timeout(1000)).importData(Mockito.any(), Mockito.any());
         Thread.sleep(50);
-        assertEquals(JobStatus.FAILED, importStatusService.getStatus());
+        assertEquals(JobStatus.PASSWORD_ERROR, importStatusService.getStatus());
+        assertEquals("Reading of decrypted data failed, maybe the provided password is incorrect?",
+                importStatusService.getMessage());
     }
 }

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -32,15 +32,16 @@ The controllers reside under `backend/src/main/java/com/my/goldmanager/controlle
 
 Data import is asynchronous. Use `POST /api/dataimport/import` with a JSON body containing `data` and
 `password`. The request returns HTTP `202 Accepted` when the import started. Poll
-`GET /api/dataimport/status` to check the current job status. The response is one of `IDLE`,
-`RUNNING`, `SUCCESS` or `FAILED`. If another import is triggered while one is
-already running the service responds with HTTP `409 Conflict`.
+`GET /api/dataimport/status` to check the current job status. The response contains the job status and
+an optional message. Possible states are `IDLE`, `RUNNING`, `SUCCESS`, `FAILED` and `PASSWORD_ERROR`.
+If another import is triggered while one is already running the service responds with HTTP `409 Conflict`.
 
 ## Data Export
 
 Data export mirrors the import workflow. Trigger the job with `POST /api/dataexport/export` providing
 `password` in the JSON body. The response is HTTP `202 Accepted` once the export started. Poll
-`GET /api/dataexport/status` until it returns `SUCCESS`, then download the result via
+`GET /api/dataexport/status` until it returns `SUCCESS`. The status payload also includes a message and
+may report `PASSWORD_ERROR` when the supplied password is invalid. Download the result via
 `GET /api/dataexport/download`. Starting a new export while one is running yields HTTP `409 Conflict`.
 
 ## Integration with the UI


### PR DESCRIPTION
## Summary
- include PASSWORD_ERROR in `JobStatus`
- capture exception messages in import/export status services
- expose status and message via new `JobStatusResponse`
- adjust controllers and tests to handle new response
- document new job status behaviour

## Testing
- `./gradlew test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843e0007dac8326995ae1794f4cb0d6