### PR TITLE
Allow import status without login

### DIFF
--- a/backend/src/main/java/com/my/goldmanager/config/DefaultSecurityConfiguration.java
+++ b/backend/src/main/java/com/my/goldmanager/config/DefaultSecurityConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
@@ -56,7 +57,10 @@ public class DefaultSecurityConfiguration {
 		http.csrf((csfr) -> csfr.disable())
 				.sessionManagement(sessionMgmt -> sessionMgmt.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(
-				(requests) -> requests.requestMatchers("/api/auth/login").permitAll().requestMatchers("/api/**").authenticated().anyRequest().permitAll())
+                                (requests) -> requests.requestMatchers("/api/auth/login").permitAll()
+                                                .requestMatchers(HttpMethod.GET, "/api/dataimport/status").permitAll()
+                                                .requestMatchers("/api/**").authenticated()
+                                                .anyRequest().permitAll())
 				.httpBasic(httpBasic -> httpBasic.disable());
 
 		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/my/goldmanager/config/DevSecurityConfiguration.java
+++ b/backend/src/main/java/com/my/goldmanager/config/DevSecurityConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 
 import com.my.goldmanager.encoder.PasswordEncoderImpl;
 import com.my.goldmanager.service.CustomUserDetailsService;
@@ -53,8 +54,11 @@ public class DevSecurityConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeHttpRequests(
-				(requests) -> requests.requestMatchers("/api/auth/login").permitAll().requestMatchers("/api/**").authenticated().anyRequest().permitAll())
+                http.authorizeHttpRequests(
+                                (requests) -> requests.requestMatchers("/api/auth/login").permitAll()
+                                                .requestMatchers(HttpMethod.GET, "/api/dataimport/status").permitAll()
+                                                .requestMatchers("/api/**").authenticated()
+                                                .anyRequest().permitAll())
 				.httpBasic(httpBasic -> httpBasic.disable()).csrf((csfr) -> csfr.disable())
 				.sessionManagement(sessionMgmt -> sessionMgmt.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/backend/src/test/java/com/my/goldmanager/config/TestSecurityConfiguration.java
+++ b/backend/src/test/java/com/my/goldmanager/config/TestSecurityConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 
 import com.my.goldmanager.encoder.PasswordEncoderImpl;
 import com.my.goldmanager.service.CustomUserDetailsService;
@@ -49,8 +50,11 @@ public class TestSecurityConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeHttpRequests(
-				(requests) -> requests.requestMatchers("/api/auth/login").permitAll().requestMatchers("/api/**").authenticated().anyRequest().permitAll())
+                http.authorizeHttpRequests(
+                                (requests) -> requests.requestMatchers("/api/auth/login").permitAll()
+                                                .requestMatchers(HttpMethod.GET, "/api/dataimport/status").permitAll()
+                                                .requestMatchers("/api/**").authenticated()
+                                                .anyRequest().permitAll())
 				.httpBasic(httpBasic -> httpBasic.disable()).csrf((csfr) -> csfr.disable());
 		;
 		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -32,7 +32,8 @@ The controllers reside under `backend/src/main/java/com/my/goldmanager/controlle
 
 Data import is asynchronous. Use `POST /api/dataimport/import` with a JSON body containing `data` and
 `password`. The request returns HTTP `202 Accepted` when the import started. Poll
-`GET /api/dataimport/status` to check the current job status. The response contains the job status and
+`GET /api/dataimport/status` to check the current job status. This endpoint is publicly accessible so the
+UI can determine if an import is in progress before logging in. The response contains the job status and
 an optional message. Possible states are `IDLE`, `RUNNING`, `SUCCESS`, `FAILED` and `PASSWORD_ERROR`.
 If another import is triggered while one is already running the service responds with HTTP `409 Conflict`.
 


### PR DESCRIPTION
## Summary
- permit unauthenticated GET `/api/dataimport/status` in all security configs
- document that import status endpoint is public

## Testing
- `./gradlew test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843f6fcb8548326b30de6e7413a8d5d