### PR TITLE
Fix decryption byte reading

### DIFF
--- a/backend/src/main/java/com/my/goldmanager/service/dataexpimp/DataExportImportUtil.java
+++ b/backend/src/main/java/com/my/goldmanager/service/dataexpimp/DataExportImportUtil.java
@@ -43,14 +43,32 @@ public class DataExportImportUtil {
 	 * @param byteArray the byte array to convert
 	 * @return the long value representation of the byte array
 	 */
-	public static long byteArrayToLong(byte[] byteArray) {
-		if (byteArray.length != 8) {
-			throw new IllegalArgumentException("Byte array must be 8 bytes long");
-		}
-		long value = 0;
-		for (int i = 0; i < 8; i++) {
-			value = (value << 8) | (byteArray[i] & 0xFF);
-		}
-		return value;
-	}
+        public static long byteArrayToLong(byte[] byteArray) {
+                if (byteArray.length != 8) {
+                        throw new IllegalArgumentException("Byte array must be 8 bytes long");
+                }
+                long value = 0;
+                for (int i = 0; i < 8; i++) {
+                        value = (value << 8) | (byteArray[i] & 0xFF);
+                }
+                return value;
+        }
+
+        /**
+         * Reads bytes from the input stream until the buffer is completely filled.
+         *
+         * @param in     the InputStream to read from
+         * @param buffer the buffer to fill
+         * @throws IOException if the stream ends before the buffer is filled
+         */
+        public static void readFully(java.io.InputStream in, byte[] buffer) throws java.io.IOException {
+                int offset = 0;
+                while (offset < buffer.length) {
+                        int read = in.read(buffer, offset, buffer.length - offset);
+                        if (read == -1) {
+                                throw new java.io.IOException("Unexpected end of stream");
+                        }
+                        offset += read;
+                }
+        }
 }

--- a/backend/src/main/java/com/my/goldmanager/service/dataexpimp/ExportDataCryptor.java
+++ b/backend/src/main/java/com/my/goldmanager/service/dataexpimp/ExportDataCryptor.java
@@ -113,18 +113,18 @@ public class ExportDataCryptor {
 				throw new ValidationException("Invalid header format");
 			}
 
-			byte[] encryptedDataSizeBytes = new byte[8];
-			inflaterInputStream.read(encryptedDataSizeBytes);
+                        byte[] encryptedDataSizeBytes = new byte[8];
+                        DataExportImportUtil.readFully(inflaterInputStream, encryptedDataSizeBytes);
 			long encryptedDataSize = DataExportImportUtil.byteArrayToLong(encryptedDataSizeBytes);
 
-			byte[] salt = new byte[16];
-			inflaterInputStream.read(salt);
+                        byte[] salt = new byte[16];
+                        DataExportImportUtil.readFully(inflaterInputStream, salt);
 
-			byte[] iv = new byte[DataExportImportCryptoUtil.IV_LENGTH];
-			inflaterInputStream.read(iv);
+                        byte[] iv = new byte[DataExportImportCryptoUtil.IV_LENGTH];
+                        DataExportImportUtil.readFully(inflaterInputStream, iv);
 
-			byte[] encryptedData = new byte[(int) encryptedDataSize];
-			inflaterInputStream.read(encryptedData);
+                        byte[] encryptedData = new byte[(int) encryptedDataSize];
+                        DataExportImportUtil.readFully(inflaterInputStream, encryptedData);
 
 			SecretKey key = DataExportImportCryptoUtil.generateKeyFromPassword(encryptionPassword, salt);
 			Cipher cipher = DataExportImportCryptoUtil.getCipher(key, iv, Cipher.DECRYPT_MODE);
@@ -142,14 +142,13 @@ public class ExportDataCryptor {
 							"Decrypted body can not be verified");
 				}
 
-				byte[] payloadSizeBytes = new byte[8];
-
-				cipherInputStream.read(payloadSizeBytes);
+                                byte[] payloadSizeBytes = new byte[8];
+                                DataExportImportUtil.readFully(cipherInputStream, payloadSizeBytes);
 
 				long payloadSize = DataExportImportUtil.byteArrayToLong(payloadSizeBytes);
 
-				byte[] payload = new byte[(int) payloadSize];
-				cipherInputStream.read(payload);
+                                byte[] payload = new byte[(int) payloadSize];
+                                DataExportImportUtil.readFully(cipherInputStream, payload);
 
 				return objectMapper.readValue(payload, ExportData.class);
 

--- a/frontend/src/components/DataImportComponent.vue
+++ b/frontend/src/components/DataImportComponent.vue
@@ -47,7 +47,6 @@ export default {
   methods: {
     ...mapActions(['logout']),
     handleFileUpload(event) {
-
       const file = event.target.files[0];
       if (!file) {
         this.fileData = null;
@@ -55,12 +54,14 @@ export default {
       }
       const reader = new FileReader();
       reader.onload = () => {
-          const arrayBuffer = reader.result;
-          const binaryString = String.fromCharCode(...new Uint8Array(arrayBuffer));
-          this.fileData = btoa(binaryString); // Convert to Base64 
+        const result = reader.result;
+        if (typeof result === 'string') {
+          const index = result.indexOf(',');
+          this.fileData = index >= 0 ? result.slice(index + 1) : result;
           this.errorMessage = '';
-    };
-    reader.readAsArrayBuffer(file); // Read file as ArrayBuffer
+        }
+      };
+      reader.readAsDataURL(file);
     },
     getImportButtonClass(){
       if(this.disableImport){


### PR DESCRIPTION
## Summary
- ensure ImportData uses full reads when decrypting
- add helper to read streams completely

## Testing
- `npm run lint`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6844699a1d608326b802b8a2cb357598