### PR TITLE
Fix npm warnings by upgrading ESLint

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,29 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  resolvePluginsRelativeTo: __dirname,
+  recommendedConfig: js.configs.recommended
+});
+
+export default [
+  ...compat.extends('plugin:vue/recommended', 'eslint:recommended'),
+  ...compat.plugins('vue'),
+  ...compat.env({ node: true }),
+  ...compat.config({
+    parser: 'vue-eslint-parser',
+    parserOptions: {
+      parser: '@babel/eslint-parser',
+      requireConfigFile: false,
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    },
+    rules: {}
+  })
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,28 +22,10 @@
     "@babel/eslint-parser": "^7.12.16",
     "@babel/preset-env": "^7.24.5",
     "@vitejs/plugin-vue": "^5.0.4",
-    "eslint": "^8.56.2",
-    "eslint-plugin-vue": "^9.27.0",
+    "eslint": "^9.28.0",
+    "eslint-plugin-vue": "^10.2.0",
     "vite": "^6.3.5",
     "vue-eslint-parser": "^10.1.3"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
-    },
-    "extends": [
-      "plugin:vue/vue3-recommended",
-      "eslint:recommended"
-    ],
-    "parser": "vue-eslint-parser",
-    "parserOptions": {
-      "parser": "@babel/eslint-parser",
-      "requireConfigFile": false,
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    },
-    "rules": {}
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
## Summary
- upgrade eslint and vue plugin
- add FlatCompat-based eslint.config.js to keep old rules

## Testing
- `npm run lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68454cf034788326997f1084c1e1c84c