### PR TITLE
Fix ESLint browser globals

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -15,7 +15,10 @@ const compat = new FlatCompat({
 export default [
   ...compat.extends('plugin:vue/recommended', 'eslint:recommended'),
   ...compat.plugins('vue'),
-  ...compat.env({ node: true }),
+  ...compat.env({
+    node: true,
+    browser: true
+  }),
   ...compat.config({
     parser: 'vue-eslint-parser',
     parserOptions: {


### PR DESCRIPTION
## Summary
- configure ESLint to use the browser environment so global objects like `sessionStorage` are recognized

## Testing
- `npm run lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68455b165c548326b4a0dfaaded77b9f