### PR TITLE
Add basic frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
 
-    - name: Install and Build Frontend
+    - name: Install and Test Frontend
       run: |
         cd frontend
         npm install
+        npm run lint
+        npm run test -- --run
         npm run build
 
     - name: Copy Frontend Build to Backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ When backend functions are added or changed, corresponding unit or integration t
 
 1. `./gradlew test` inside `backend/`
 2. `npm run lint` inside `frontend/`
+3. `npm run test` inside `frontend/`
 
 Include any relevant outputs in the PR description.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please see also https://github.com/goldmanager/goldmanager-dockercompose for an 
 
 ## Development setup
 
-The frontend is built and tested with Node.js 20. Install dependencies with `npm install` inside `frontend/` before running `npm run lint` or starting the dev server.
+The frontend is built and tested with Node.js 20. Install dependencies with `npm install` inside `frontend/` before running `npm run lint` and `npm run test` or starting the dev server.
 The backend requires Java 21 and can be tested with `./gradlew test` in the `backend/` directory.
 
 ## Data Import

--- a/docs/third_party_licenses.md
+++ b/docs/third_party_licenses.md
@@ -13,5 +13,7 @@ This project uses several open source dependencies. The following table lists ke
 | Byte Buddy | Apache-2.0 |
 | Mockito | MIT |
 | Vue, Vite and related frontend packages | MIT |
+| Vitest | MIT |
+| Vue Test Utils | MIT |
 
 All listed licenses are permissive or weak copyleft and are compatible with use under the Apache License 2.0. For LGPL and MPL/EPL components, ensure they remain separate libraries when distributing the application and keep the original license notices intact.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint --ext .js,.vue src"
+    "lint": "eslint --ext .js,.vue src",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.7.2",
@@ -25,7 +26,10 @@
     "eslint": "^9.28.0",
     "eslint-plugin-vue": "^10.2.0",
     "vite": "^6.3.5",
-    "vue-eslint-parser": "^10.1.3"
+    "vue-eslint-parser": "^10.1.3",
+    "@vue/test-utils": "^2.4.6",
+    "vitest": "^3.2.2",
+    "jsdom": "^24.0.0"
   },
   "browserslist": [
     "> 1%",

--- a/frontend/tests/NavBar.spec.js
+++ b/frontend/tests/NavBar.spec.js
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import NavBar from '../src/components/NavBar.vue'
+
+const mountWithAuth = (isAuth) => {
+  const store = createStore({
+    getters: {
+      isAuthenticated: () => isAuth
+    },
+    actions: {
+      logout: () => {}
+    }
+  })
+
+  return mount(NavBar, {
+    global: {
+      plugins: [store],
+      stubs: ['router-link']
+    }
+  })
+}
+
+describe('NavBar', () => {
+  it('shows login link when not authenticated', () => {
+    const wrapper = mountWithAuth(false)
+    const loginLink = wrapper.find('router-link-stub[to="/login"]')
+    expect(loginLink.exists()).toBe(true)
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('shows logout button when authenticated', () => {
+    const wrapper = mountWithAuth(true)
+    expect(wrapper.find('button').text()).toBe('Logout')
+    const linkTexts = wrapper.findAll('router-link-stub').map(l => l.text())
+    expect(linkTexts).not.toContain('Login')
+  })
+})

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -1,9 +1,13 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [vue()],
+  test: {
+    globals: true,
+    environment: 'jsdom'
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
## Summary
- add Vitest and Vue Test Utils
- configure Vitest in `vite.config.mjs`
- add a sample test for `NavBar`
- document frontend tests and update license list
- run lint and tests in CI

## Testing
- `npm run lint`
- `npm run test -- --run`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68458f3bd1908326af9ce9006dbde5c8