### PR TITLE
Add frontend unit tests

### DIFF
--- a/frontend/tests/DataExportComponent.spec.js
+++ b/frontend/tests/DataExportComponent.spec.js
@@ -1,0 +1,49 @@
+import { mount } from '@vue/test-utils'
+import DataExportComponent from '../src/components/DataExportComponent.vue'
+import axios from '../src/axios'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn()
+  }
+}))
+
+const defaultData = {
+  exportPassword: '',
+  exportPasswordConfirm: '',
+  errorMessage: '',
+  statusMessage: '',
+  exportStatusMessage: '',
+  showExportStatus: false,
+  statusIntervalId: null,
+  exportStatus: '',
+  exportStarted: false
+}
+
+const mountComponent = (overrides = {}) =>
+  mount(DataExportComponent, {
+    data() {
+      return { ...defaultData, ...overrides }
+    },
+    global: { stubs: ['el-date-picker'] }
+  })
+
+describe('DataExportComponent', () => {
+  it('disables export while running', async () => {
+    axios.get.mockResolvedValue({ data: { status: 'RUNNING' } })
+    const wrapper = mountComponent()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.disableExport).toBe(true)
+    expect(wrapper.vm.getExportButtonClass()).toBe('actionbutton_disabled')
+  })
+
+  it('enables export when idle', async () => {
+    axios.get.mockResolvedValue({ data: { status: '' } })
+    const wrapper = mountComponent()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.disableExport).toBe(false)
+    expect(wrapper.vm.getExportButtonClass()).toBe('actionbutton')
+  })
+})

--- a/frontend/tests/DataImportComponent.spec.js
+++ b/frontend/tests/DataImportComponent.spec.js
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils'
+import DataImportComponent from '../src/components/DataImportComponent.vue'
+import axios from '../src/axios'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn()
+  }
+}))
+
+const mountComponent = (overrides = {}) =>
+  mount(DataImportComponent, {
+    data() {
+      return { ...overrides }
+    },
+    methods: { checkImportStatus: vi.fn(), startStatusInterval: vi.fn() }
+  })
+
+describe('DataImportComponent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('disables import when status is running', () => {
+    const wrapper = mountComponent({ fileData: 'x', importStatus: 'RUNNING' })
+    expect(wrapper.vm.disableImport).toBe(true)
+    expect(wrapper.vm.getImportButtonClass()).toBe('actionbutton_disabled')
+  })
+
+  it('shows error when passwords do not match', async () => {
+    const wrapper = mountComponent({ fileData: 'abc' })
+    await wrapper.setData({ importPassword: 'a', importPasswordConfirm: 'b' })
+    await wrapper.vm.importData()
+    expect(wrapper.vm.errorMessage).toBe('Passwords do not match!')
+  })
+})

--- a/frontend/tests/ItemsComponent.spec.js
+++ b/frontend/tests/ItemsComponent.spec.js
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils'
+import ItemsComponent from '../src/components/ItemsComponent.vue'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const mountComponent = async () => {
+  const wrapper = mount(ItemsComponent, {
+    methods: { fetchData: vi.fn() }
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('ItemsComponent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('filters items by search query', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setData({
+      items: [
+        { id: 1, name: 'Gold', itemType: { name: 't' }, unit: { name: 'u' }, itemStorage: { name: '' }, amount: 1, itemCount: 1 },
+        { id: 2, name: 'Silver', itemType: { name: 't' }, unit: { name: 'u' }, itemStorage: { name: '' }, amount: 2, itemCount: 1 }
+      ],
+      currentSort: 'name',
+      currentSortDir: 'asc',
+      searchQuery: 'gold'
+    })
+    expect(wrapper.vm.filteredObjects).toHaveLength(1)
+    expect(wrapper.vm.filteredObjects[0].name).toBe('Gold')
+  })
+
+  it('paginates items', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setData({
+      items: [
+        { id: 1, name: 'A', itemType: { name: 't' }, unit: { name: 'u' }, itemStorage: { name: '' }, amount: 1, itemCount: 1 },
+        { id: 2, name: 'B', itemType: { name: 't' }, unit: { name: 'u' }, itemStorage: { name: '' }, amount: 2, itemCount: 1 },
+        { id: 3, name: 'C', itemType: { name: 't' }, unit: { name: 'u' }, itemStorage: { name: '' }, amount: 3, itemCount: 1 }
+      ],
+      currentSort: 'name',
+      currentSortDir: 'asc',
+      pageSize: 2
+    })
+    expect(wrapper.vm.paginatedObjects.map(o => o.name)).toEqual(['A', 'B'])
+    wrapper.vm.nextPage()
+    expect(wrapper.vm.paginatedObjects.map(o => o.name)).toEqual(['C'])
+    wrapper.vm.prevPage()
+    expect(wrapper.vm.paginatedObjects.map(o => o.name)).toEqual(['A', 'B'])
+  })
+})

--- a/frontend/tests/LoginComponent.spec.js
+++ b/frontend/tests/LoginComponent.spec.js
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import LoginComponent from '../src/components/LoginComponent.vue'
+import axios from '../src/axios'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../src/axios', () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn().mockResolvedValue({ data: { status: '' } })
+  }
+}))
+
+const mountComponent = () => {
+  const loginAction = vi.fn()
+  const store = createStore({
+    actions: { login: loginAction }
+  })
+  const router = { push: vi.fn() }
+  const wrapper = mount(LoginComponent, {
+    global: {
+      plugins: [store],
+      mocks: { $router: router }
+    }
+  })
+  return { wrapper, loginAction, router }
+}
+
+describe('LoginComponent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('displays error message on failed login', async () => {
+    axios.post.mockRejectedValue(new Error('fail'))
+    const { wrapper } = mountComponent()
+    await wrapper.setData({ username: 'u', password: 'p' })
+    await wrapper.find('form').trigger('submit.prevent')
+    expect(wrapper.vm.errorMessage).toBe('Login failed. Please check your credentials.')
+  })
+
+  it('dispatches login action on success', async () => {
+    axios.post.mockResolvedValue({ data: { token: 't', refreshAfter: 'r' } })
+    const { wrapper, loginAction, router } = mountComponent()
+    await wrapper.setData({ username: 'u', password: 'p' })
+    await wrapper.find('form').trigger('submit.prevent')
+    expect(loginAction).toHaveBeenCalled()
+    expect(router.push).toHaveBeenCalledWith('/')
+  })
+})

--- a/frontend/tests/PriceChart.spec.js
+++ b/frontend/tests/PriceChart.spec.js
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils'
+import PriceChart from '../src/components/PriceChart.vue'
+
+describe('PriceChart', () => {
+  it('creates chart data from modelValue', () => {
+    const prices = [
+      { date: '2024-01-01', totalPrice: 10, metalPrice: 5 },
+      { date: '2024-01-02', totalPrice: 15, metalPrice: 8 }
+    ]
+    const wrapper = mount(PriceChart, {
+      props: { modelValue: prices },
+      global: {
+        stubs: {
+          'line-chart': true
+        }
+      }
+    })
+
+    const chartData = wrapper.vm.chartData
+    expect(chartData.labels).toEqual(['2024-01-01', '2024-01-02'])
+    expect(chartData.datasets[0].data).toEqual([10, 15])
+    expect(chartData.datasets[1].data).toEqual([5, 8])
+  })
+})

--- a/frontend/tests/store.spec.js
+++ b/frontend/tests/store.spec.js
@@ -1,0 +1,18 @@
+import store from '../src/store'
+
+describe('Vuex store authentication', () => {
+  beforeEach(() => {
+    store.replaceState({ isAuthenticated: false })
+  })
+
+  it('login action sets authentication state', async () => {
+    await store.dispatch('login')
+    expect(store.getters.isAuthenticated).toBe(true)
+  })
+
+  it('logout action clears authentication state', async () => {
+    store.replaceState({ isAuthenticated: true })
+    await store.dispatch('logout')
+    expect(store.getters.isAuthenticated).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- extend frontend tests with a price chart test
- add tests for store authentication logic

## Testing
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6845961b44808326b904087e876269a6