### PR TITLE
Enable same‑origin CORS

### DIFF
--- a/backend/src/main/java/com/my/goldmanager/config/DefaultSecurityConfiguration.java
+++ b/backend/src/main/java/com/my/goldmanager/config/DefaultSecurityConfiguration.java
@@ -53,11 +53,12 @@ public class DefaultSecurityConfiguration {
 	@Autowired
 	private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-	@Bean
-        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-               http.csrf(csrf -> csrf
-                               .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                               .ignoringRequestMatchers("/api/auth/csrf", "/api/auth/login"))
+       @Bean
+       public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+               http.cors(cors -> cors.configure(http))
+                               .csrf(csrf -> csrf
+                                               .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                                               .ignoringRequestMatchers("/api/auth/csrf", "/api/auth/login"))
                                .sessionManagement(sessionMgmt -> sessionMgmt.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                                .authorizeHttpRequests(
                                                requests -> requests.requestMatchers("/api/auth/login").permitAll()
@@ -65,7 +66,8 @@ public class DefaultSecurityConfiguration {
                                                                 .requestMatchers(HttpMethod.GET, "/api/dataimport/status").permitAll()
                                                                 .requestMatchers("/api/**").authenticated()
                                                                 .anyRequest().permitAll())
-                                .httpBasic(httpBasic -> httpBasic.disable());
+                               .httpBasic(httpBasic -> httpBasic.disable())
+                               .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()));
 
 		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 		return http.build();

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -4,7 +4,7 @@ This document provides an overview of the backend REST API and how it is consume
 
 ## Overview
 
-The backend exposes a set of endpoints under the `/api` prefix. They allow management of materials, items and prices of precious metals. Authentication is handled with JWT tokens. During development the `dev` Spring profile enables CORS to allow local UI servers.
+The backend exposes a set of endpoints under the `/api` prefix. They allow management of materials, items and prices of precious metals. Authentication is handled with JWT tokens. During development the `dev` Spring profile enables CORS to allow local UI servers. In production the `default` profile configures CORS with a same-origin policy so the built Vue frontend served by Spring Boot can reach the API.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- activate CORS in `DefaultSecurityConfiguration` and use `sameOrigin` frame option
- document that production uses same-origin CORS for the built frontend

## Testing
- `./gradlew test --no-daemon` *(fails: Could not download dependencies)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*
- `npm run test` *(fails: dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846c99861ec8326a225a28b19d16ac4