### PR TITLE
Fix CSRF header mismatch

### DIFF
--- a/backend/src/main/java/com/my/goldmanager/controller/AuthController.java
+++ b/backend/src/main/java/com/my/goldmanager/controller/AuthController.java
@@ -63,7 +63,7 @@ public class AuthController {
                                                .getAttribute(org.springframework.security.web.csrf.CsrfToken.class.getName());
                if (token != null) {
                        return ResponseEntity.noContent()
-                                       .header("X-CSRF-TOKEN", token.getToken())
+                                       .header("X-XSRF-TOKEN", token.getToken())
                                        .build();
                }
                return ResponseEntity.noContent().build();


### PR DESCRIPTION
## Summary
- fix CSRF endpoint to send `X-XSRF-TOKEN` header

## Testing
- `./gradlew test`
- `npm run lint`
- `npm run test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_e_68471b0b4d3c832685e0d471371a630b