### PR TITLE
Improve security code tests

### DIFF
--- a/backend/src/test/java/com/my/goldmanager/config/filter/UIWebFilterTest.java
+++ b/backend/src/test/java/com/my/goldmanager/config/filter/UIWebFilterTest.java
@@ -1,0 +1,43 @@
+package com.my.goldmanager.config.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class UIWebFilterTest {
+
+    private final UIWebFilter filter = new UIWebFilter();
+
+    @Test
+    void nonApiRequestIsForwarded() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/home");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals("/index.html", response.getForwardedUrl());
+        // Filter chain should not have been invoked
+        assertNull(chain.getRequest());
+    }
+
+    @Test
+    void apiRequestIsPassedThrough() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/items");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNull(response.getForwardedUrl());
+        // Filter chain should receive the request
+        assertEquals(request, chain.getRequest());
+    }
+}

--- a/backend/src/test/java/com/my/goldmanager/encoder/PasswordEncoderImplTest.java
+++ b/backend/src/test/java/com/my/goldmanager/encoder/PasswordEncoderImplTest.java
@@ -1,0 +1,17 @@
+package com.my.goldmanager.encoder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class PasswordEncoderImplTest {
+
+    private final PasswordEncoderImpl encoder = new PasswordEncoderImpl();
+
+    @Test
+    void encodedPasswordMatches() {
+        String raw = "secret";
+        String encoded = encoder.encode(raw);
+        assertTrue(encoder.matches(raw, encoded));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for UIWebFilter
- add unit tests for PasswordEncoderImpl

## Testing
- `./gradlew test`
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6849eb9a4e64832680cd85789950cad4