### PR TITLE
Resolve frontend npm audit warning

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@babel/eslint-parser": "^7.12.16",
     "@babel/preset-env": "^7.24.5",
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vue/test-utils": "^2.4.6",
+    "@vue/test-utils": "^2.2.7",
     "eslint": "^9.28.0",
     "eslint-plugin-vue": "^10.2.0",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Summary
- address npm audit warning by downgrading `@vue/test-utils`
- ensure linter and unit tests run without failures

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6849f047059c8326842826c23f42d2a6