### PR TITLE
Add coverage tests for untested components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@babel/eslint-parser": "^7.12.16",
     "@babel/preset-env": "^7.24.5",
     "@vitejs/plugin-vue": "^5.0.4",
+    "@vitest/coverage-v8": "^3.2.3",
     "@vue/test-utils": "^2.2.7",
     "eslint": "^9.28.0",
     "eslint-plugin-vue": "^10.2.0",

--- a/frontend/tests/ItemStorages.spec.js
+++ b/frontend/tests/ItemStorages.spec.js
@@ -1,0 +1,59 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({})
+  }
+}))
+import { mount } from '@vue/test-utils'
+import ItemStorages from '../src/components/ItemStorages.vue'
+
+const mountComponent = async () => {
+  vi.spyOn(ItemStorages.methods, 'fetchData').mockResolvedValue()
+  const wrapper = mount(ItemStorages)
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('ItemStorages', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('filters storages by search query', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setData({
+      itemStorages: [
+        { id: 1, name: 'Store A', description: 'x' },
+        { id: 2, name: 'Store B', description: 'y' }
+      ],
+      currentSort: 'name',
+      currentSortDir: 'asc',
+      searchQuery: 'store a'
+    })
+    expect(wrapper.vm.filteredObjects).toHaveLength(1)
+    expect(wrapper.vm.filteredObjects[0].name).toBe('Store A')
+  })
+
+  it('paginates storages', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setData({
+      itemStorages: [
+        { id: 1, name: 'A', description: '' },
+        { id: 2, name: 'B', description: '' },
+        { id: 3, name: 'C', description: '' }
+      ],
+      currentSort: 'name',
+      currentSortDir: 'asc',
+      pageSize: 2
+    })
+    expect(wrapper.vm.paginatedObjects.map(o => o.name)).toEqual(['A', 'B'])
+    wrapper.vm.nextPage()
+    expect(wrapper.vm.paginatedObjects.map(o => o.name)).toEqual(['C'])
+    wrapper.vm.prevPage()
+    expect(wrapper.vm.paginatedObjects.map(o => o.name)).toEqual(['A', 'B'])
+  })
+})

--- a/frontend/tests/ItemTypes.spec.js
+++ b/frontend/tests/ItemTypes.spec.js
@@ -1,0 +1,51 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({})
+  }
+}))
+import { mount } from '@vue/test-utils'
+import ItemTypes from '../src/components/ItemTypes.vue'
+
+const mountComponent = async () => {
+  vi.spyOn(ItemTypes.methods, 'fetchData').mockResolvedValue()
+  const wrapper = mount(ItemTypes)
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('ItemTypes', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('resolves material names', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setData({
+      metals: [
+        { value: 1, text: 'Gold' },
+        { value: 2, text: 'Silver' }
+      ]
+    })
+    expect(wrapper.vm.getMaterialName(2)).toBe('Silver')
+  })
+
+  it('filters types by search query', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setData({
+      itemTypes: [
+        { id: 1, name: 'Coin', modifier: 1, material: { name: 'Gold' } },
+        { id: 2, name: 'Bar', modifier: 1, material: { name: 'Gold' } }
+      ],
+      currentSort: 'name',
+      currentSortDir: 'asc',
+      searchQuery: 'coi'
+    })
+    expect(wrapper.vm.filteredObjects).toHaveLength(1)
+    expect(wrapper.vm.filteredObjects[0].name).toBe('Coin')
+  })
+})

--- a/frontend/tests/MetalsComponent.spec.js
+++ b/frontend/tests/MetalsComponent.spec.js
@@ -1,0 +1,44 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({})
+  }
+}))
+import { mount } from '@vue/test-utils'
+import MetalsComponent from '../src/components/MetalsComponent.vue'
+
+// element-plus css cannot be processed in tests
+vi.mock('element-plus/theme-chalk/el-date-picker.css', () => ({}), { virtual: true })
+vi.mock('element-plus', () => ({ ElDatePicker: { name: 'el-date-picker', template: '<div />' } }))
+vi.mock('element-plus/es/components/date-picker/style/css', () => ({}), { virtual: true })
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+const mountComponent = async () => {
+  vi.spyOn(MetalsComponent.methods, 'fetchMetals').mockResolvedValue()
+  const wrapper = mount(MetalsComponent)
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('MetalsComponent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('formats dates with leading zeros', async () => {
+    const wrapper = await mountComponent()
+    const date = new Date('2024-01-02T03:04:00')
+    expect(wrapper.vm.formatDateCustom(date)).toBe('2024-01-02T03:04:00.000')
+  })
+})

--- a/frontend/tests/PriceHistoryComponent.spec.js
+++ b/frontend/tests/PriceHistoryComponent.spec.js
@@ -1,0 +1,52 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({})
+  }
+}))
+import { mount } from '@vue/test-utils'
+import PriceHistoryComponent from '../src/components/PriceHistoryComponent.vue'
+
+// element-plus imports css which Node can't handle during tests
+vi.mock('element-plus/theme-chalk/el-date-picker.css', () => ({}), { virtual: true })
+vi.mock('element-plus', () => ({ ElDatePicker: { name: 'el-date-picker', template: '<div />' } }))
+vi.mock('element-plus/es/components/date-picker/style/css', () => ({}), { virtual: true })
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+const mountComponent = async () => {
+  vi.spyOn(PriceHistoryComponent.methods, 'fetchData').mockResolvedValue()
+  vi.spyOn(PriceHistoryComponent.methods, 'fetchPriceHistories').mockResolvedValue()
+  const wrapper = mount(PriceHistoryComponent)
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('PriceHistoryComponent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('computes default date range starting from Jan 1st', async () => {
+    const wrapper = await mountComponent()
+    const [start, end] = wrapper.vm.getDefaultDateRange()
+    expect(start).toMatch(/^\d{4}-01-01T/)
+    expect(end).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('adds timezone offset to date string', async () => {
+    const wrapper = await mountComponent()
+    const result = wrapper.vm.addOffsetToDateString('2024-01-01T00:00:00.000')
+    expect(result).toMatch(/\d{4}-01-01T00:00:00\.000(?:%2b|-)\d{2}:\d{2}$/)
+  })
+})

--- a/frontend/tests/UnitsComponent.spec.js
+++ b/frontend/tests/UnitsComponent.spec.js
@@ -1,0 +1,47 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({})
+  }
+}))
+import { mount } from '@vue/test-utils'
+import UnitsComponent from '../src/components/UnitsComponent.vue'
+
+vi.mock('../src/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+const mountComponent = async () => {
+  vi.spyOn(UnitsComponent.methods, 'fetchUnits').mockResolvedValue()
+  const wrapper = mount(UnitsComponent)
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('UnitsComponent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('sorts units by name', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setData({
+      units: [
+        { name: 'b', factor: 1 },
+        { name: 'a', factor: 1 }
+      ],
+      currentSort: 'name',
+      currentSortDir: 'asc'
+    })
+    expect(wrapper.vm.sortedObjects.map(u => u.name)).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest coverage helper
- create tests for ItemStorages, ItemTypes, MetalsComponent, PriceHistoryComponent and UnitsComponent
- mock axios and Element Plus to avoid network and CSS issues

## Testing
- `npm run test`
- `npm run test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6849f3b84d9c8326825eb38f46472fd3